### PR TITLE
Update for runtime 23.08 or Python 3.11

### DIFF
--- a/clinic/_tkinter.c.h
+++ b/clinic/_tkinter.c.h
@@ -322,21 +322,13 @@ PyDoc_STRVAR(_tkinter_tkapp_splitlist__doc__,
 #define _TKINTER_TKAPP_SPLITLIST_METHODDEF    \
     {"splitlist", (PyCFunction)_tkinter_tkapp_splitlist, METH_O, _tkinter_tkapp_splitlist__doc__},
 
-PyDoc_STRVAR(_tkinter_tkapp_split__doc__,
-"split($self, arg, /)\n"
-"--\n"
-"\n");
-
-#define _TKINTER_TKAPP_SPLIT_METHODDEF    \
-    {"split", (PyCFunction)_tkinter_tkapp_split, METH_O, _tkinter_tkapp_split__doc__},
-
 PyDoc_STRVAR(_tkinter_tkapp_createcommand__doc__,
 "createcommand($self, name, func, /)\n"
 "--\n"
 "\n");
 
 #define _TKINTER_TKAPP_CREATECOMMAND_METHODDEF    \
-    {"createcommand", (PyCFunction)(void(*)(void))_tkinter_tkapp_createcommand, METH_FASTCALL, _tkinter_tkapp_createcommand__doc__},
+    {"createcommand", _PyCFunction_CAST(_tkinter_tkapp_createcommand), METH_FASTCALL, _tkinter_tkapp_createcommand__doc__},
 
 static PyObject *
 _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
@@ -416,7 +408,7 @@ PyDoc_STRVAR(_tkinter_tkapp_createfilehandler__doc__,
 "\n");
 
 #define _TKINTER_TKAPP_CREATEFILEHANDLER_METHODDEF    \
-    {"createfilehandler", (PyCFunction)(void(*)(void))_tkinter_tkapp_createfilehandler, METH_FASTCALL, _tkinter_tkapp_createfilehandler__doc__},
+    {"createfilehandler", _PyCFunction_CAST(_tkinter_tkapp_createfilehandler), METH_FASTCALL, _tkinter_tkapp_createfilehandler__doc__},
 
 static PyObject *
 _tkinter_tkapp_createfilehandler_impl(TkappObject *self, PyObject *file,
@@ -434,11 +426,6 @@ _tkinter_tkapp_createfilehandler(TkappObject *self, PyObject *const *args, Py_ss
         goto exit;
     }
     file = args[0];
-    if (PyFloat_Check(args[1])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
     mask = _PyLong_AsInt(args[1]);
     if (mask == -1 && PyErr_Occurred()) {
         goto exit;
@@ -487,7 +474,7 @@ PyDoc_STRVAR(_tkinter_tkapp_createtimerhandler__doc__,
 "\n");
 
 #define _TKINTER_TKAPP_CREATETIMERHANDLER_METHODDEF    \
-    {"createtimerhandler", (PyCFunction)(void(*)(void))_tkinter_tkapp_createtimerhandler, METH_FASTCALL, _tkinter_tkapp_createtimerhandler__doc__},
+    {"createtimerhandler", _PyCFunction_CAST(_tkinter_tkapp_createtimerhandler), METH_FASTCALL, _tkinter_tkapp_createtimerhandler__doc__},
 
 static PyObject *
 _tkinter_tkapp_createtimerhandler_impl(TkappObject *self, int milliseconds,
@@ -501,11 +488,6 @@ _tkinter_tkapp_createtimerhandler(TkappObject *self, PyObject *const *args, Py_s
     PyObject *func;
 
     if (!_PyArg_CheckPositional("createtimerhandler", nargs, 2, 2)) {
-        goto exit;
-    }
-    if (PyFloat_Check(args[0])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
         goto exit;
     }
     milliseconds = _PyLong_AsInt(args[0]);
@@ -525,7 +507,7 @@ PyDoc_STRVAR(_tkinter_tkapp_mainloop__doc__,
 "\n");
 
 #define _TKINTER_TKAPP_MAINLOOP_METHODDEF    \
-    {"mainloop", (PyCFunction)(void(*)(void))_tkinter_tkapp_mainloop, METH_FASTCALL, _tkinter_tkapp_mainloop__doc__},
+    {"mainloop", _PyCFunction_CAST(_tkinter_tkapp_mainloop), METH_FASTCALL, _tkinter_tkapp_mainloop__doc__},
 
 static PyObject *
 _tkinter_tkapp_mainloop_impl(TkappObject *self, int threshold);
@@ -541,11 +523,6 @@ _tkinter_tkapp_mainloop(TkappObject *self, PyObject *const *args, Py_ssize_t nar
     }
     if (nargs < 1) {
         goto skip_optional;
-    }
-    if (PyFloat_Check(args[0])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
     }
     threshold = _PyLong_AsInt(args[0]);
     if (threshold == -1 && PyErr_Occurred()) {
@@ -564,7 +541,7 @@ PyDoc_STRVAR(_tkinter_tkapp_dooneevent__doc__,
 "\n");
 
 #define _TKINTER_TKAPP_DOONEEVENT_METHODDEF    \
-    {"dooneevent", (PyCFunction)(void(*)(void))_tkinter_tkapp_dooneevent, METH_FASTCALL, _tkinter_tkapp_dooneevent__doc__},
+    {"dooneevent", _PyCFunction_CAST(_tkinter_tkapp_dooneevent), METH_FASTCALL, _tkinter_tkapp_dooneevent__doc__},
 
 static PyObject *
 _tkinter_tkapp_dooneevent_impl(TkappObject *self, int flags);
@@ -580,11 +557,6 @@ _tkinter_tkapp_dooneevent(TkappObject *self, PyObject *const *args, Py_ssize_t n
     }
     if (nargs < 1) {
         goto skip_optional;
-    }
-    if (PyFloat_Check(args[0])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
     }
     flags = _PyLong_AsInt(args[0]);
     if (flags == -1 && PyErr_Occurred()) {
@@ -689,7 +661,7 @@ PyDoc_STRVAR(_tkinter_create__doc__,
 "    if not None, then pass -use to wish");
 
 #define _TKINTER_CREATE_METHODDEF    \
-    {"create", (PyCFunction)(void(*)(void))_tkinter_create, METH_FASTCALL, _tkinter_create__doc__},
+    {"create", _PyCFunction_CAST(_tkinter_create), METH_FASTCALL, _tkinter_create__doc__},
 
 static PyObject *
 _tkinter_create_impl(PyObject *module, const char *screenName,
@@ -769,22 +741,12 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (nargs < 4) {
         goto skip_optional;
     }
-    if (PyFloat_Check(args[3])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
     interactive = _PyLong_AsInt(args[3]);
     if (interactive == -1 && PyErr_Occurred()) {
         goto exit;
     }
     if (nargs < 5) {
         goto skip_optional;
-    }
-    if (PyFloat_Check(args[4])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
     }
     wantobjects = _PyLong_AsInt(args[4]);
     if (wantobjects == -1 && PyErr_Occurred()) {
@@ -793,22 +755,12 @@ _tkinter_create(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (nargs < 6) {
         goto skip_optional;
     }
-    if (PyFloat_Check(args[5])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
     wantTk = _PyLong_AsInt(args[5]);
     if (wantTk == -1 && PyErr_Occurred()) {
         goto exit;
     }
     if (nargs < 7) {
         goto skip_optional;
-    }
-    if (PyFloat_Check(args[6])) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
     }
     sync = _PyLong_AsInt(args[6]);
     if (sync == -1 && PyErr_Occurred()) {
@@ -862,11 +814,6 @@ _tkinter_setbusywaitinterval(PyObject *module, PyObject *arg)
     PyObject *return_value = NULL;
     int new_val;
 
-    if (PyFloat_Check(arg)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "integer argument expected, got float" );
-        goto exit;
-    }
     new_val = _PyLong_AsInt(arg);
     if (new_val == -1 && PyErr_Occurred()) {
         goto exit;
@@ -912,4 +859,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=492b8b833fe54bc9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b0667ac928eb0c28 input=a9049054013a1b77]*/

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ module1 = Extension('_tkinter',
 
 setup(
     name='tkinter-standalone',
-    version='3.9',
+    version='3.11',
     description='Tkinter packaged as an external package for flatpak.',
     ext_modules=[module1],
     packages=["tkinter"]

--- a/tkinter.h
+++ b/tkinter.h
@@ -25,4 +25,3 @@
 #endif
 
 #endif /* !TKINTER_H */
-

--- a/tkinter/commondialog.py
+++ b/tkinter/commondialog.py
@@ -10,7 +10,7 @@
 
 __all__ = ["Dialog"]
 
-from tkinter import Frame
+from tkinter import Frame, _get_temp_root, _destroy_temp_root
 
 
 class Dialog:
@@ -18,7 +18,7 @@ class Dialog:
     command = None
 
     def __init__(self, master=None, **options):
-        if not master:
+        if master is None:
             master = options.get('parent')
         self.master = master
         self.options = options
@@ -37,22 +37,17 @@ class Dialog:
 
         self._fixoptions()
 
-        # we need a dummy widget to properly process the options
-        # (at least as long as we use Tkinter 1.63)
-        w = Frame(self.master)
-
+        master = self.master
+        if master is None:
+            master = _get_temp_root()
         try:
-
-            s = w.tk.call(self.command, *w._options(self.options))
-
-            s = self._fixresult(w, s)
-
+            self._test_callback(master)  # The function below is replaced for some tests.
+            s = master.tk.call(self.command, *master._options(self.options))
+            s = self._fixresult(master, s)
         finally:
-
-            try:
-                # get rid of the widget
-                w.destroy()
-            except:
-                pass
+            _destroy_temp_root(master)
 
         return s
+
+    def _test_callback(self, master):
+        pass

--- a/tkinter/dialog.py
+++ b/tkinter/dialog.py
@@ -11,7 +11,7 @@ class Dialog(Widget):
     def __init__(self, master=None, cnf={}, **kw):
         cnf = _cnfmerge((cnf, kw))
         self.widgetName = '__dialog__'
-        Widget._setup(self, master, cnf)
+        self._setup(master, cnf)
         self.num = self.tk.getint(
                 self.tk.call(
                       'tk_dialog', self._w,

--- a/tkinter/dnd.py
+++ b/tkinter/dnd.py
@@ -108,7 +108,7 @@ __all__ = ["dnd_start", "DndHandler"]
 
 def dnd_start(source, event):
     h = DndHandler(source, event)
-    if h.root:
+    if h.root is not None:
         return h
     else:
         return None
@@ -143,7 +143,7 @@ class DndHandler:
     def __del__(self):
         root = self.root
         self.root = None
-        if root:
+        if root is not None:
             try:
                 del root.__dnd
             except AttributeError:
@@ -154,25 +154,25 @@ class DndHandler:
         target_widget = self.initial_widget.winfo_containing(x, y)
         source = self.source
         new_target = None
-        while target_widget:
+        while target_widget is not None:
             try:
                 attr = target_widget.dnd_accept
             except AttributeError:
                 pass
             else:
                 new_target = attr(source, event)
-                if new_target:
+                if new_target is not None:
                     break
             target_widget = target_widget.master
         old_target = self.target
         if old_target is new_target:
-            if old_target:
+            if old_target is not None:
                 old_target.dnd_motion(source, event)
         else:
-            if old_target:
+            if old_target is not None:
                 self.target = None
                 old_target.dnd_leave(source, event)
-            if new_target:
+            if new_target is not None:
                 new_target.dnd_enter(source, event)
                 self.target = new_target
 
@@ -193,7 +193,7 @@ class DndHandler:
             self.initial_widget.unbind("<Motion>")
             widget['cursor'] = self.save_cursor
             self.target = self.source = self.initial_widget = self.root = None
-            if target:
+            if target is not None:
                 if commit:
                     target.dnd_commit(source, event)
                 else:
@@ -215,9 +215,9 @@ class Icon:
         if canvas is self.canvas:
             self.canvas.coords(self.id, x, y)
             return
-        if self.canvas:
+        if self.canvas is not None:
             self.detach()
-        if not canvas:
+        if canvas is None:
             return
         label = tkinter.Label(canvas, text=self.name,
                               borderwidth=2, relief="raised")
@@ -229,7 +229,7 @@ class Icon:
 
     def detach(self):
         canvas = self.canvas
-        if not canvas:
+        if canvas is None:
             return
         id = self.id
         label = self.label

--- a/tkinter/font.py
+++ b/tkinter/font.py
@@ -17,10 +17,10 @@ BOLD   = "bold"
 ITALIC = "italic"
 
 
-def nametofont(name):
+def nametofont(name, root=None):
     """Given the name of a tk named font, returns a Font representation.
     """
-    return Font(name=name, exists=True)
+    return Font(name=name, exists=True, root=root)
 
 
 class Font:
@@ -68,7 +68,7 @@ class Font:
 
     def __init__(self, root=None, font=None, name=None, exists=False,
                  **options):
-        if not root:
+        if root is None:
             root = tkinter._get_default_root('use font')
         tk = getattr(root, 'tk', root)
         if font:
@@ -99,6 +99,10 @@ class Font:
 
     def __str__(self):
         return self.name
+
+    def __repr__(self):
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__}" \
+               f" object {self.name!r}>"
 
     def __eq__(self, other):
         if not isinstance(other, Font):
@@ -179,7 +183,7 @@ class Font:
 
 def families(root=None, displayof=None):
     "Get font families (as a tuple)"
-    if not root:
+    if root is None:
         root = tkinter._get_default_root('use font.families()')
     args = ()
     if displayof:
@@ -189,7 +193,7 @@ def families(root=None, displayof=None):
 
 def names(root=None):
     "Get names of defined fonts (as a tuple)"
-    if not root:
+    if root is None:
         root = tkinter._get_default_root('use font.names()')
     return root.tk.splitlist(root.tk.call("font", "names"))
 

--- a/tkinter/simpledialog.py
+++ b/tkinter/simpledialog.py
@@ -24,7 +24,8 @@ askstring -- get a string from the user
 """
 
 from tkinter import *
-from tkinter import messagebox, _get_default_root
+from tkinter import _get_temp_root, _destroy_temp_root
+from tkinter import messagebox
 
 
 class SimpleDialog:
@@ -58,36 +59,8 @@ class SimpleDialog:
                 b.config(relief=RIDGE, borderwidth=8)
             b.pack(side=LEFT, fill=BOTH, expand=1)
         self.root.protocol('WM_DELETE_WINDOW', self.wm_delete_window)
-        self._set_transient(master)
-
-    def _set_transient(self, master, relx=0.5, rely=0.3):
-        widget = self.root
-        widget.withdraw() # Remain invisible while we figure out the geometry
-        widget.transient(master)
-        widget.update_idletasks() # Actualize geometry information
-        if master.winfo_ismapped():
-            m_width = master.winfo_width()
-            m_height = master.winfo_height()
-            m_x = master.winfo_rootx()
-            m_y = master.winfo_rooty()
-        else:
-            m_width = master.winfo_screenwidth()
-            m_height = master.winfo_screenheight()
-            m_x = m_y = 0
-        w_width = widget.winfo_reqwidth()
-        w_height = widget.winfo_reqheight()
-        x = m_x + (m_width - w_width) * relx
-        y = m_y + (m_height - w_height) * rely
-        if x+w_width > master.winfo_screenwidth():
-            x = master.winfo_screenwidth() - w_width
-        elif x < 0:
-            x = 0
-        if y+w_height > master.winfo_screenheight():
-            y = master.winfo_screenheight() - w_height
-        elif y < 0:
-            y = 0
-        widget.geometry("+%d+%d" % (x, y))
-        widget.deiconify() # Become visible at the desired location
+        self.root.transient(master)
+        _place_window(self.root, master)
 
     def go(self):
         self.root.wait_visibility()
@@ -130,8 +103,8 @@ class Dialog(Toplevel):
             title -- the dialog title
         '''
         master = parent
-        if not master:
-            master = _get_default_root('create dialog window')
+        if master is None:
+            master = _get_temp_root()
 
         Toplevel.__init__(self, master)
 
@@ -157,16 +130,12 @@ class Dialog(Toplevel):
 
         self.buttonbox()
 
-        if not self.initial_focus:
+        if self.initial_focus is None:
             self.initial_focus = self
 
         self.protocol("WM_DELETE_WINDOW", self.cancel)
 
-        if parent is not None:
-            self.geometry("+%d+%d" % (parent.winfo_rootx()+50,
-                                      parent.winfo_rooty()+50))
-
-        self.deiconify() # become visible now
+        _place_window(self, parent)
 
         self.initial_focus.focus_set()
 
@@ -179,6 +148,7 @@ class Dialog(Toplevel):
         '''Destroy the window'''
         self.initial_focus = None
         Toplevel.destroy(self)
+        _destroy_temp_root(self.master)
 
     #
     # construction hooks
@@ -254,6 +224,37 @@ class Dialog(Toplevel):
         '''
 
         pass # override
+
+
+# Place a toplevel window at the center of parent or screen
+# It is a Python implementation of ::tk::PlaceWindow.
+def _place_window(w, parent=None):
+    w.wm_withdraw() # Remain invisible while we figure out the geometry
+    w.update_idletasks() # Actualize geometry information
+
+    minwidth = w.winfo_reqwidth()
+    minheight = w.winfo_reqheight()
+    maxwidth = w.winfo_vrootwidth()
+    maxheight = w.winfo_vrootheight()
+    if parent is not None and parent.winfo_ismapped():
+        x = parent.winfo_rootx() + (parent.winfo_width() - minwidth) // 2
+        y = parent.winfo_rooty() + (parent.winfo_height() - minheight) // 2
+        vrootx = w.winfo_vrootx()
+        vrooty = w.winfo_vrooty()
+        x = min(x, vrootx + maxwidth - minwidth)
+        x = max(x, vrootx)
+        y = min(y, vrooty + maxheight - minheight)
+        y = max(y, vrooty)
+        if w._windowingsystem == 'aqua':
+            # Avoid the native menu bar which sits on top of everything.
+            y = max(y, 22)
+    else:
+        x = (w.winfo_screenwidth() - minwidth) // 2
+        y = (w.winfo_screenheight() - minheight) // 2
+
+    w.wm_maxsize(maxwidth, maxheight)
+    w.wm_geometry('+%d+%d' % (x, y))
+    w.wm_deiconify() # Become visible at the desired location
 
 
 def _setup_dialog(w):

--- a/tkinter/test/test_tkinter/test_colorchooser.py
+++ b/tkinter/test/test_tkinter/test_colorchooser.py
@@ -1,8 +1,10 @@
 import unittest
 import tkinter
 from test.support import requires, swap_attr
-from tkinter.test.support import AbstractTkTest
+from tkinter.test.support import AbstractDefaultRootTest, AbstractTkTest
 from tkinter import colorchooser
+from tkinter.colorchooser import askcolor
+from tkinter.commondialog import Dialog
 
 requires('gui')
 
@@ -35,6 +37,31 @@ class ChooserTest(AbstractTkTest, unittest.TestCase):
                          ((210, 105, 30), 'chocolate'))
         self.assertEqual(cc._fixresult(self.root, '#4a3c8c'),
                          ((74, 60, 140), '#4a3c8c'))
+
+
+class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
+
+    def test_askcolor(self):
+        def test_callback(dialog, master):
+            nonlocal ismapped
+            master.update()
+            ismapped = master.winfo_ismapped()
+            raise ZeroDivisionError
+
+        with swap_attr(Dialog, '_test_callback', test_callback):
+            ismapped = None
+            self.assertRaises(ZeroDivisionError, askcolor)
+            #askcolor()
+            self.assertEqual(ismapped, False)
+
+            root = tkinter.Tk()
+            ismapped = None
+            self.assertRaises(ZeroDivisionError, askcolor)
+            self.assertEqual(ismapped, True)
+            root.destroy()
+
+            tkinter.NoDefaultRoot()
+            self.assertRaises(RuntimeError, askcolor)
 
 
 if __name__ == "__main__":

--- a/tkinter/test/test_tkinter/test_font.py
+++ b/tkinter/test/test_tkinter/test_font.py
@@ -108,6 +108,16 @@ class FontTest(AbstractTkTest, unittest.TestCase):
             self.assertTrue(name)
         self.assertIn(fontname, names)
 
+    def test_nametofont(self):
+        testfont = font.nametofont(fontname, root=self.root)
+        self.assertIsInstance(testfont, font.Font)
+        self.assertEqual(testfont.name, fontname)
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.font), f'<tkinter.font.Font object {fontname!r}>'
+        )
+
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
 
@@ -137,6 +147,16 @@ class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
         root.destroy()
         tkinter.NoDefaultRoot()
         self.assertRaises(RuntimeError, font.names)
+
+    def test_nametofont(self):
+        self.assertRaises(RuntimeError, font.nametofont, fontname)
+        root = tkinter.Tk()
+        testfont = font.nametofont(fontname)
+        self.assertIsInstance(testfont, font.Font)
+        self.assertEqual(testfont.name, fontname)
+        root.destroy()
+        tkinter.NoDefaultRoot()
+        self.assertRaises(RuntimeError, font.nametofont, fontname)
 
 
 if __name__ == "__main__":

--- a/tkinter/test/test_tkinter/test_geometry_managers.py
+++ b/tkinter/test/test_tkinter/test_geometry_managers.py
@@ -4,7 +4,7 @@ import tkinter
 from tkinter import TclError
 from test.support import requires
 
-from tkinter.test.support import pixels_conv, tcl_version, requires_tcl
+from tkinter.test.support import pixels_conv
 from tkinter.test.widget_tests import AbstractWidgetTest
 
 requires('gui')
@@ -108,8 +108,8 @@ class PackTest(AbstractWidgetTest, unittest.TestCase):
         a.pack_configure(in_=c)
         self.assertEqual(pack.pack_slaves(), [b, c, d])
         self.assertEqual(c.pack_slaves(), [a])
-        with self.assertRaisesRegex(TclError,
-                                    'can\'t pack %s inside itself' % (a,)):
+        with self.assertRaisesRegex(
+                TclError, """can't pack "?%s"? inside itself""" % (a,)):
             a.pack_configure(in_=a)
         with self.assertRaisesRegex(TclError, 'bad window path name ".foo"'):
             a.pack_configure(in_='.foo')
@@ -292,11 +292,12 @@ class PlaceTest(AbstractWidgetTest, unittest.TestCase):
     def test_place_configure_in(self):
         t, f, f2 = self.create2()
         self.assertEqual(f2.winfo_manager(), '')
-        with self.assertRaisesRegex(TclError, "can't place %s relative to "
-                                    "itself" % re.escape(str(f2))):
+        with self.assertRaisesRegex(
+                TclError,
+                """can't place "?%s"? relative to itself"""
+                 % re.escape(str(f2))):
             f2.place_configure(in_=f2)
-        if tcl_version >= (8, 5):
-            self.assertEqual(f2.winfo_manager(), '')
+        self.assertEqual(f2.winfo_manager(), '')
         with self.assertRaisesRegex(TclError, 'bad window path name'):
             f2.place_configure(in_='spam')
         f2.place_configure(in_=f)
@@ -491,8 +492,7 @@ class GridTest(AbstractWidgetTest, unittest.TestCase):
         for i in range(rows + 1):
             self.root.grid_rowconfigure(i, weight=0, minsize=0, pad=0, uniform='')
         self.root.grid_propagate(1)
-        if tcl_version >= (8, 5):
-            self.root.grid_anchor('nw')
+        self.root.grid_anchor('nw')
         super().tearDown()
 
     def test_grid_configure(self):
@@ -619,16 +619,14 @@ class GridTest(AbstractWidgetTest, unittest.TestCase):
             self.root.grid_columnconfigure((0, 3))
         b = tkinter.Button(self.root)
         b.grid_configure(column=0, row=0)
-        if tcl_version >= (8, 5):
-            self.root.grid_columnconfigure('all', weight=3)
-            with self.assertRaisesRegex(TclError, 'expected integer but got "all"'):
-                self.root.grid_columnconfigure('all')
-            self.assertEqual(self.root.grid_columnconfigure(0, 'weight'), 3)
+        self.root.grid_columnconfigure('all', weight=3)
+        with self.assertRaisesRegex(TclError, 'expected integer but got "all"'):
+            self.root.grid_columnconfigure('all')
+        self.assertEqual(self.root.grid_columnconfigure(0, 'weight'), 3)
         self.assertEqual(self.root.grid_columnconfigure(3, 'weight'), 2)
         self.assertEqual(self.root.grid_columnconfigure(265, 'weight'), 0)
-        if tcl_version >= (8, 5):
-            self.root.grid_columnconfigure(b, weight=4)
-            self.assertEqual(self.root.grid_columnconfigure(0, 'weight'), 4)
+        self.root.grid_columnconfigure(b, weight=4)
+        self.assertEqual(self.root.grid_columnconfigure(0, 'weight'), 4)
 
     def test_grid_columnconfigure_minsize(self):
         with self.assertRaisesRegex(TclError, 'bad screen distance "foo"'):
@@ -675,16 +673,14 @@ class GridTest(AbstractWidgetTest, unittest.TestCase):
             self.root.grid_rowconfigure((0, 3))
         b = tkinter.Button(self.root)
         b.grid_configure(column=0, row=0)
-        if tcl_version >= (8, 5):
-            self.root.grid_rowconfigure('all', weight=3)
-            with self.assertRaisesRegex(TclError, 'expected integer but got "all"'):
-                self.root.grid_rowconfigure('all')
-            self.assertEqual(self.root.grid_rowconfigure(0, 'weight'), 3)
+        self.root.grid_rowconfigure('all', weight=3)
+        with self.assertRaisesRegex(TclError, 'expected integer but got "all"'):
+            self.root.grid_rowconfigure('all')
+        self.assertEqual(self.root.grid_rowconfigure(0, 'weight'), 3)
         self.assertEqual(self.root.grid_rowconfigure(3, 'weight'), 2)
         self.assertEqual(self.root.grid_rowconfigure(265, 'weight'), 0)
-        if tcl_version >= (8, 5):
-            self.root.grid_rowconfigure(b, weight=4)
-            self.assertEqual(self.root.grid_rowconfigure(0, 'weight'), 4)
+        self.root.grid_rowconfigure(b, weight=4)
+        self.assertEqual(self.root.grid_rowconfigure(0, 'weight'), 4)
 
     def test_grid_rowconfigure_minsize(self):
         with self.assertRaisesRegex(TclError, 'bad screen distance "foo"'):
@@ -774,7 +770,6 @@ class GridTest(AbstractWidgetTest, unittest.TestCase):
         self.assertEqual(info['pady'], self._str(4))
         self.assertEqual(info['sticky'], 'ns')
 
-    @requires_tcl(8, 5)
     def test_grid_anchor(self):
         with self.assertRaisesRegex(TclError, 'bad anchor "x"'):
             self.root.grid_anchor('x')

--- a/tkinter/test/test_tkinter/test_images.py
+++ b/tkinter/test/test_tkinter/test_images.py
@@ -1,7 +1,8 @@
 import unittest
 import tkinter
 from test import support
-from tkinter.test.support import AbstractTkTest, AbstractDefaultRootTest, requires_tcl
+from test.support import os_helper
+from tkinter.test.support import AbstractTkTest, AbstractDefaultRootTest, requires_tk
 
 support.requires('gui')
 
@@ -143,6 +144,14 @@ class BitmapImageTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(image['foreground'],
                          '-foreground {} {} #000000 yellow')
 
+    def test_bug_100814(self):
+        # gh-100814: Passing a callable option value causes AttributeError.
+        with self.assertRaises(tkinter.TclError):
+            tkinter.BitmapImage('::img::test', master=self.root, spam=print)
+        image = tkinter.BitmapImage('::img::test', master=self.root)
+        with self.assertRaises(tkinter.TclError):
+            image.configure(spam=print)
+
 
 class PhotoImageTest(AbstractTkTest, unittest.TestCase):
 
@@ -212,11 +221,11 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
     def test_create_from_gif_data(self):
         self.check_create_from_data('gif')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_create_from_png_file(self):
         self.check_create_from_file('png')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_create_from_png_data(self):
         self.check_create_from_data('png')
 
@@ -272,6 +281,14 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(image['palette'], '256')
         image.configure(palette='3/4/2')
         self.assertEqual(image['palette'], '3/4/2')
+
+    def test_bug_100814(self):
+        # gh-100814: Passing a callable option value causes AttributeError.
+        with self.assertRaises(tkinter.TclError):
+            tkinter.PhotoImage('::img::test', master=self.root, spam=print)
+        image = tkinter.PhotoImage('::img::test', master=self.root)
+        with self.assertRaises(tkinter.TclError):
+            image.configure(spam=print)
 
     def test_blank(self):
         image = self.create()
@@ -340,13 +357,18 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, image.get, 15, 16)
 
     def test_write(self):
+        filename = os_helper.TESTFN
+        import locale
+        if locale.getlocale()[0] is None:
+            # Tcl uses Latin1 in the C locale
+            filename = os_helper.TESTFN_ASCII
         image = self.create()
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, filename)
 
-        image.write(support.TESTFN)
+        image.write(filename)
         image2 = tkinter.PhotoImage('::img::test2', master=self.root,
                                     format='ppm',
-                                    file=support.TESTFN)
+                                    file=filename)
         self.assertEqual(str(image2), '::img::test2')
         self.assertEqual(image2.type(), 'photo')
         self.assertEqual(image2.width(), 16)
@@ -354,10 +376,10 @@ class PhotoImageTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(image2.get(0, 0), image.get(0, 0))
         self.assertEqual(image2.get(15, 8), image.get(15, 8))
 
-        image.write(support.TESTFN, format='gif', from_coords=(4, 6, 6, 9))
+        image.write(filename, format='gif', from_coords=(4, 6, 6, 9))
         image3 = tkinter.PhotoImage('::img::test3', master=self.root,
                                     format='gif',
-                                    file=support.TESTFN)
+                                    file=filename)
         self.assertEqual(str(image3), '::img::test3')
         self.assertEqual(image3.type(), 'photo')
         self.assertEqual(image3.width(), 2)

--- a/tkinter/test/test_tkinter/test_loadtk.py
+++ b/tkinter/test/test_tkinter/test_loadtk.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import test.support as test_support
+from test.support import os_helper
 from tkinter import Tcl, TclError
 
 test_support.requires('gui')
@@ -24,7 +25,7 @@ class TkLoadTest(unittest.TestCase):
             # XXX Maybe on tk older than 8.4.13 it would be possible,
             # see tkinter.h.
             return
-        with test_support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             if 'DISPLAY' in os.environ:
                 del env['DISPLAY']
                 # on some platforms, deleting environment variables

--- a/tkinter/test/test_tkinter/test_misc.py
+++ b/tkinter/test/test_tkinter/test_misc.py
@@ -1,5 +1,7 @@
+import functools
 import unittest
 import tkinter
+import enum
 from test import support
 from tkinter.test.support import AbstractTkTest, AbstractDefaultRootTest
 
@@ -96,6 +98,12 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(count, 53)
         with self.assertRaises(tkinter.TclError):
             root.tk.call(script)
+
+        # Call with a callable class
+        count = 0
+        timer1 = root.after(0, functools.partial(callback, 42, 11))
+        root.update()  # Process all pending events.
+        self.assertEqual(count, 53)
 
     def test_after_idle(self):
         root = self.root
@@ -268,6 +276,49 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
                          " num=3 delta=-1 focus=True"
                          " x=10 y=20 width=300 height=200>")
 
+    def test_eventtype_enum(self):
+        class CheckedEventType(enum.StrEnum):
+            KeyPress = '2'
+            Key = KeyPress
+            KeyRelease = '3'
+            ButtonPress = '4'
+            Button = ButtonPress
+            ButtonRelease = '5'
+            Motion = '6'
+            Enter = '7'
+            Leave = '8'
+            FocusIn = '9'
+            FocusOut = '10'
+            Keymap = '11'           # undocumented
+            Expose = '12'
+            GraphicsExpose = '13'   # undocumented
+            NoExpose = '14'         # undocumented
+            Visibility = '15'
+            Create = '16'
+            Destroy = '17'
+            Unmap = '18'
+            Map = '19'
+            MapRequest = '20'
+            Reparent = '21'
+            Configure = '22'
+            ConfigureRequest = '23'
+            Gravity = '24'
+            ResizeRequest = '25'
+            Circulate = '26'
+            CirculateRequest = '27'
+            Property = '28'
+            SelectionClear = '29'   # undocumented
+            SelectionRequest = '30' # undocumented
+            Selection = '31'        # undocumented
+            Colormap = '32'
+            ClientMessage = '33'    # undocumented
+            Mapping = '34'          # undocumented
+            VirtualEvent = '35'     # undocumented
+            Activate = '36'
+            Deactivate = '37'
+            MouseWheel = '38'
+        enum._test_simple_enum(CheckedEventType, tkinter.EventType)
+
     def test_getboolean(self):
         for v in 'true', 'yes', 'on', '1', 't', 'y', 1, True:
             self.assertIs(self.root.getboolean(v), True)
@@ -289,6 +340,338 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.root.mainloop(0)
         self.assertEqual(log, [1])
         self.assertTrue(self.root.winfo_exists())
+
+    def test_info_patchlevel(self):
+        vi = self.root.info_patchlevel()
+        f = tkinter.Frame(self.root)
+        self.assertEqual(f.info_patchlevel(), vi)
+        # The following is almost a copy of tests for sys.version_info.
+        self.assertIsInstance(vi[:], tuple)
+        self.assertEqual(len(vi), 5)
+        self.assertIsInstance(vi[0], int)
+        self.assertIsInstance(vi[1], int)
+        self.assertIsInstance(vi[2], int)
+        self.assertIn(vi[3], ("alpha", "beta", "candidate", "final"))
+        self.assertIsInstance(vi[4], int)
+        self.assertIsInstance(vi.major, int)
+        self.assertIsInstance(vi.minor, int)
+        self.assertIsInstance(vi.micro, int)
+        self.assertIn(vi.releaselevel, ("alpha", "beta", "final"))
+        self.assertIsInstance(vi.serial, int)
+        self.assertEqual(vi[0], vi.major)
+        self.assertEqual(vi[1], vi.minor)
+        self.assertEqual(vi[2], vi.micro)
+        self.assertEqual(vi[3], vi.releaselevel)
+        self.assertEqual(vi[4], vi.serial)
+        self.assertTrue(vi > (1,0,0))
+        if vi.releaselevel == 'final':
+            self.assertEqual(vi.serial, 0)
+        else:
+            self.assertEqual(vi.micro, 0)
+        self.assertTrue(str(vi).startswith(f'{vi.major}.{vi.minor}'))
+
+
+class BindTest(AbstractTkTest, unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        root = self.root
+        self.frame = tkinter.Frame(self.root, class_='Test',
+                                   width=150, height=100)
+        self.frame.pack()
+
+    def assertCommandExist(self, funcid):
+        self.assertEqual(_info_commands(self.root, funcid), (funcid,))
+
+    def assertCommandNotExist(self, funcid):
+        self.assertEqual(_info_commands(self.root, funcid), ())
+
+    def test_bind(self):
+        event = '<Control-Alt-Key-a>'
+        f = self.frame
+        self.assertEqual(f.bind(), ())
+        self.assertEqual(f.bind(event), '')
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = f.bind(event, test1)
+        self.assertEqual(f.bind(), (event,))
+        script = f.bind(event)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+
+        funcid2 = f.bind(event, test2, add=True)
+        script = f.bind(event)
+        self.assertIn(funcid, script)
+        self.assertIn(funcid2, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+    def test_unbind(self):
+        event = '<Control-Alt-Key-b>'
+        f = self.frame
+        self.assertEqual(f.bind(), ())
+        self.assertEqual(f.bind(event), '')
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = f.bind(event, test1)
+        funcid2 = f.bind(event, test2, add=True)
+
+        self.assertRaises(TypeError, f.unbind)
+        f.unbind(event)
+        self.assertEqual(f.bind(event), '')
+        self.assertEqual(f.bind(), ())
+
+    def test_unbind2(self):
+        f = self.frame
+        event = '<Control-Alt-Key-c>'
+        self.assertEqual(f.bind(), ())
+        self.assertEqual(f.bind(event), '')
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = f.bind(event, test1)
+        funcid2 = f.bind(event, test2, add=True)
+
+        f.unbind(event, funcid)
+        script = f.bind(event)
+        self.assertNotIn(funcid, script)
+        self.assertCommandNotExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        f.unbind(event, funcid2)
+        self.assertEqual(f.bind(event), '')
+        self.assertEqual(f.bind(), ())
+        self.assertCommandNotExist(funcid)
+        self.assertCommandNotExist(funcid2)
+
+        # non-idempotent
+        self.assertRaises(tkinter.TclError, f.unbind, event, funcid2)
+
+    def test_bind_rebind(self):
+        event = '<Control-Alt-Key-d>'
+        f = self.frame
+        self.assertEqual(f.bind(), ())
+        self.assertEqual(f.bind(event), '')
+        def test1(e): pass
+        def test2(e): pass
+        def test3(e): pass
+
+        funcid = f.bind(event, test1)
+        funcid2 = f.bind(event, test2, add=True)
+        script = f.bind(event)
+        self.assertIn(funcid2, script)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        funcid3 = f.bind(event, test3)
+        script = f.bind(event)
+        self.assertNotIn(funcid, script)
+        self.assertNotIn(funcid2, script)
+        self.assertIn(funcid3, script)
+        self.assertCommandExist(funcid3)
+
+    def test_bind_class(self):
+        event = '<Control-Alt-Key-e>'
+        bind_class = self.root.bind_class
+        unbind_class = self.root.unbind_class
+        self.assertRaises(TypeError, bind_class)
+        self.assertEqual(bind_class('Test'), ())
+        self.assertEqual(bind_class('Test', event), '')
+        self.addCleanup(unbind_class, 'Test', event)
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = bind_class('Test', event, test1)
+        self.assertEqual(bind_class('Test'), (event,))
+        script = bind_class('Test', event)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+
+        funcid2 = bind_class('Test', event, test2, add=True)
+        script = bind_class('Test', event)
+        self.assertIn(funcid, script)
+        self.assertIn(funcid2, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+    def test_unbind_class(self):
+        event = '<Control-Alt-Key-f>'
+        bind_class = self.root.bind_class
+        unbind_class = self.root.unbind_class
+        self.assertEqual(bind_class('Test'), ())
+        self.assertEqual(bind_class('Test', event), '')
+        self.addCleanup(unbind_class, 'Test', event)
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = bind_class('Test', event, test1)
+        funcid2 = bind_class('Test', event, test2, add=True)
+
+        self.assertRaises(TypeError, unbind_class)
+        self.assertRaises(TypeError, unbind_class, 'Test')
+        unbind_class('Test', event)
+        self.assertEqual(bind_class('Test', event), '')
+        self.assertEqual(bind_class('Test'), ())
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        unbind_class('Test', event)  # idempotent
+
+    def test_bind_class_rebind(self):
+        event = '<Control-Alt-Key-g>'
+        bind_class = self.root.bind_class
+        unbind_class = self.root.unbind_class
+        self.assertEqual(bind_class('Test'), ())
+        self.assertEqual(bind_class('Test', event), '')
+        self.addCleanup(unbind_class, 'Test', event)
+        def test1(e): pass
+        def test2(e): pass
+        def test3(e): pass
+
+        funcid = bind_class('Test', event, test1)
+        funcid2 = bind_class('Test', event, test2, add=True)
+        script = bind_class('Test', event)
+        self.assertIn(funcid2, script)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        funcid3 = bind_class('Test', event, test3)
+        script = bind_class('Test', event)
+        self.assertNotIn(funcid, script)
+        self.assertNotIn(funcid2, script)
+        self.assertIn(funcid3, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+        self.assertCommandExist(funcid3)
+
+    def test_bind_all(self):
+        event = '<Control-Alt-Key-h>'
+        bind_all = self.root.bind_all
+        unbind_all = self.root.unbind_all
+        self.assertNotIn(event, bind_all())
+        self.assertEqual(bind_all(event), '')
+        self.addCleanup(unbind_all, event)
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = bind_all(event, test1)
+        self.assertIn(event, bind_all())
+        script = bind_all(event)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+
+        funcid2 = bind_all(event, test2, add=True)
+        script = bind_all(event)
+        self.assertIn(funcid, script)
+        self.assertIn(funcid2, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+    def test_unbind_all(self):
+        event = '<Control-Alt-Key-i>'
+        bind_all = self.root.bind_all
+        unbind_all = self.root.unbind_all
+        self.assertNotIn(event, bind_all())
+        self.assertEqual(bind_all(event), '')
+        self.addCleanup(unbind_all, event)
+        def test1(e): pass
+        def test2(e): pass
+
+        funcid = bind_all(event, test1)
+        funcid2 = bind_all(event, test2, add=True)
+
+        unbind_all(event)
+        self.assertEqual(bind_all(event), '')
+        self.assertNotIn(event, bind_all())
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        unbind_all(event)  # idempotent
+
+    def test_bind_all_rebind(self):
+        event = '<Control-Alt-Key-j>'
+        bind_all = self.root.bind_all
+        unbind_all = self.root.unbind_all
+        self.assertNotIn(event, bind_all())
+        self.assertEqual(bind_all(event), '')
+        self.addCleanup(unbind_all, event)
+        def test1(e): pass
+        def test2(e): pass
+        def test3(e): pass
+
+        funcid = bind_all(event, test1)
+        funcid2 = bind_all(event, test2, add=True)
+        script = bind_all(event)
+        self.assertIn(funcid2, script)
+        self.assertIn(funcid, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+
+        funcid3 = bind_all(event, test3)
+        script = bind_all(event)
+        self.assertNotIn(funcid, script)
+        self.assertNotIn(funcid2, script)
+        self.assertIn(funcid3, script)
+        self.assertCommandExist(funcid)
+        self.assertCommandExist(funcid2)
+        self.assertCommandExist(funcid3)
+
+    def test_bindtags(self):
+        f = self.frame
+        self.assertEqual(self.root.bindtags(), ('.', 'Tk', 'all'))
+        self.assertEqual(f.bindtags(), (str(f), 'Test', '.', 'all'))
+        f.bindtags(('a', 'b c'))
+        self.assertEqual(f.bindtags(), ('a', 'b c'))
+
+    def test_bind_events(self):
+        event = '<Enter>'
+        root = self.root
+        t = tkinter.Toplevel(root)
+        f = tkinter.Frame(t, class_='Test', width=150, height=100)
+        f.pack()
+        root.wait_visibility()  # needed on Windows
+        root.update_idletasks()
+        self.addCleanup(root.unbind_class, 'Test', event)
+        self.addCleanup(root.unbind_class, 'Toplevel', event)
+        self.addCleanup(root.unbind_class, 'tag', event)
+        self.addCleanup(root.unbind_class, 'tag2', event)
+        self.addCleanup(root.unbind_all, event)
+        def test(what):
+            return lambda e: events.append((what, e.widget))
+
+        root.bind_all(event, test('all'))
+        root.bind_class('Test', event, test('frame class'))
+        root.bind_class('Toplevel', event, test('toplevel class'))
+        root.bind_class('tag', event, test('tag'))
+        root.bind_class('tag2', event, test('tag2'))
+        f.bind(event, test('frame'))
+        t.bind(event, test('toplevel'))
+
+        events = []
+        f.event_generate(event)
+        self.assertEqual(events, [
+            ('frame', f),
+            ('frame class', f),
+            ('toplevel', f),
+            ('all', f),
+        ])
+
+        events = []
+        t.event_generate(event)
+        self.assertEqual(events, [
+            ('toplevel', t),
+            ('toplevel class', t),
+            ('all', t),
+        ])
+
+        f.bindtags(('tag', 'tag3'))
+        events = []
+        f.event_generate(event)
+        self.assertEqual(events, [('tag', f)])
 
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
@@ -344,6 +727,10 @@ class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
         root.destroy()
         tkinter.NoDefaultRoot()
         self.assertRaises(RuntimeError, tkinter.mainloop)
+
+
+def _info_commands(widget, pattern=None):
+    return widget.tk.splitlist(widget.tk.call('info', 'commands', pattern))
 
 
 if __name__ == "__main__":

--- a/tkinter/test/test_tkinter/test_simpledialog.py
+++ b/tkinter/test/test_tkinter/test_simpledialog.py
@@ -10,13 +10,25 @@ requires('gui')
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
 
     def test_askinteger(self):
-        self.assertRaises(RuntimeError, askinteger, "Go To Line", "Line number")
-        root = tkinter.Tk()
-        with swap_attr(Dialog, 'wait_window', lambda self, w: w.destroy()):
+        @staticmethod
+        def mock_wait_window(w):
+            nonlocal ismapped
+            ismapped = w.master.winfo_ismapped()
+            w.destroy()
+
+        with swap_attr(Dialog, 'wait_window', mock_wait_window):
+            ismapped = None
             askinteger("Go To Line", "Line number")
-        root.destroy()
-        tkinter.NoDefaultRoot()
-        self.assertRaises(RuntimeError, askinteger, "Go To Line", "Line number")
+            self.assertEqual(ismapped, False)
+
+            root = tkinter.Tk()
+            ismapped = None
+            askinteger("Go To Line", "Line number")
+            self.assertEqual(ismapped, True)
+            root.destroy()
+
+            tkinter.NoDefaultRoot()
+            self.assertRaises(RuntimeError, askinteger, "Go To Line", "Line number")
 
 
 if __name__ == "__main__":

--- a/tkinter/test/test_tkinter/test_text.py
+++ b/tkinter/test/test_tkinter/test_text.py
@@ -40,6 +40,58 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(text.search('-test', '1.0', 'end'), '1.2')
         self.assertEqual(text.search('test', '1.0', 'end'), '1.3')
 
+    def test_count(self):
+        # XXX Some assertions do not check against the intended result,
+        # but instead check the current result to prevent regression.
+        text = self.text
+        text.insert('1.0',
+            'Lorem ipsum dolor sit amet,\n'
+            'consectetur adipiscing elit,\n'
+            'sed do eiusmod tempor incididunt\n'
+            'ut labore et dolore magna aliqua.')
+
+        options = ('chars', 'indices', 'lines',
+                   'displaychars', 'displayindices', 'displaylines',
+                   'xpixels', 'ypixels')
+        if self.wantobjects:
+            self.assertEqual(len(text.count('1.0', 'end', *options)), 8)
+        else:
+            text.count('1.0', 'end', *options)
+        self.assertEqual(text.count('1.0', 'end', 'chars', 'lines'), (124, 4)
+                         if self.wantobjects else '124 4')
+        self.assertEqual(text.count('1.3', '4.5', 'chars', 'lines'), (92, 3)
+                         if self.wantobjects else '92 3')
+        self.assertEqual(text.count('4.5', '1.3', 'chars', 'lines'), (-92, -3)
+                         if self.wantobjects else '-92 -3')
+        self.assertEqual(text.count('1.3', '1.3', 'chars', 'lines'), (0, 0)
+                         if self.wantobjects else '0 0')
+        self.assertEqual(text.count('1.0', 'end', 'lines'), (4,)
+                         if self.wantobjects else ('4',))
+        self.assertEqual(text.count('end', '1.0', 'lines'), (-4,)
+                         if self.wantobjects else ('-4',))
+        self.assertEqual(text.count('1.3', '1.5', 'lines'), None
+                         if self.wantobjects else ('0',))
+        self.assertEqual(text.count('1.3', '1.3', 'lines'), None
+                         if self.wantobjects else ('0',))
+        self.assertEqual(text.count('1.0', 'end'), (124,)  # 'indices' by default
+                         if self.wantobjects else ('124',))
+        self.assertRaises(tkinter.TclError, text.count, '1.0', 'end', 'spam')
+        self.assertRaises(tkinter.TclError, text.count, '1.0', 'end', '-lines')
+
+        self.assertIsInstance(text.count('1.3', '1.5', 'ypixels'), tuple)
+        self.assertIsInstance(text.count('1.3', '1.5', 'update', 'ypixels'), int
+                              if self.wantobjects else str)
+        self.assertEqual(text.count('1.3', '1.3', 'update', 'ypixels'), None
+                         if self.wantobjects else '0')
+        self.assertEqual(text.count('1.3', '1.5', 'update', 'indices'), 2
+                         if self.wantobjects else '2')
+        self.assertEqual(text.count('1.3', '1.3', 'update', 'indices'), None
+                         if self.wantobjects else '0')
+        self.assertEqual(text.count('1.3', '1.5', 'update'), (2,)
+                         if self.wantobjects else ('2',))
+        self.assertEqual(text.count('1.3', '1.3', 'update'), None
+                         if self.wantobjects else ('0',))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tkinter/test/test_tkinter/test_widgets.py
+++ b/tkinter/test/test_tkinter/test_widgets.py
@@ -4,11 +4,11 @@ from tkinter import TclError
 import os
 from test.support import requires
 
-from tkinter.test.support import (tcl_version, requires_tcl,
+from tkinter.test.support import (requires_tk,
                                   get_tk_patchlevel, widget_eq,
                                   AbstractDefaultRootTest)
 from tkinter.test.widget_tests import (
-    add_standard_options, noconv, pixels_round,
+    add_standard_options,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
 
@@ -20,7 +20,7 @@ def float_round(x):
 
 
 class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
-    _conv_pad_pixels = noconv
+    _conv_pad_pixels = False
 
     def test_configure_class(self):
         widget = self.create()
@@ -77,6 +77,8 @@ class ToplevelTest(AbstractToplevelTest, unittest.TestCase):
 
     def test_configure_screen(self):
         widget = self.create()
+        if widget._windowingsystem != 'x11':
+            self.skipTest('Not using Tk for X11')
         self.assertEqual(widget['screen'], '')
         try:
             display = os.environ['DISPLAY']
@@ -139,7 +141,7 @@ class LabelFrameTest(AbstractToplevelTest, unittest.TestCase):
 
 
 class AbstractLabelTest(AbstractWidgetTest, IntegerSizeTests):
-    _conv_pixels = noconv
+    _conv_pixels = False
 
     def test_configure_highlightthickness(self):
         widget = self.create()
@@ -212,6 +214,32 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
         widget = self.create()
         self.checkParams(widget, 'onvalue', 1, 2.3, '', 'any string')
 
+    def test_unique_variables(self):
+        frames = []
+        buttons = []
+        for i in range(2):
+            f = tkinter.Frame(self.root)
+            f.pack()
+            frames.append(f)
+            for j in 'AB':
+                b = tkinter.Checkbutton(f, text=j)
+                b.pack()
+                buttons.append(b)
+        variables = [str(b['variable']) for b in buttons]
+        self.assertEqual(len(set(variables)), 4, variables)
+
+    def test_same_name(self):
+        f1 = tkinter.Frame(self.root)
+        f2 = tkinter.Frame(self.root)
+        b1 = tkinter.Checkbutton(f1, name='test', text='Test1')
+        b2 = tkinter.Checkbutton(f2, name='test', text='Test2')
+
+        v = tkinter.IntVar(self.root, name='test')
+        b1.select()
+        self.assertEqual(v.get(), 1)
+        b2.deselect()
+        self.assertEqual(v.get(), 0)
+
 
 @add_standard_options(StandardOptionsTests)
 class RadiobuttonTest(AbstractLabelTest, unittest.TestCase):
@@ -249,7 +277,7 @@ class MenubuttonTest(AbstractLabelTest, unittest.TestCase):
         'takefocus', 'text', 'textvariable',
         'underline', 'width', 'wraplength',
     )
-    _conv_pixels = staticmethod(pixels_round)
+    _conv_pixels = round
 
     def create(self, **kwargs):
         return tkinter.Menubutton(self.root, **kwargs)
@@ -345,10 +373,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         self.checkPixelsParam(widget, 'insertwidth', 1.3, 3.6, '10p')
         self.checkParam(widget, 'insertwidth', 0.1, expected=2)
         self.checkParam(widget, 'insertwidth', -2, expected=2)
-        if pixels_round(0.9) <= 0:
-            self.checkParam(widget, 'insertwidth', 0.9, expected=2)
-        else:
-            self.checkParam(widget, 'insertwidth', 0.9, expected=1)
+        self.checkParam(widget, 'insertwidth', 0.9, expected=1)
 
     def test_configure_invalidcommand(self):
         widget = self.create()
@@ -550,8 +575,6 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         'tabs', 'tabstyle', 'takefocus', 'undo', 'width', 'wrap',
         'xscrollcommand', 'yscrollcommand',
     )
-    if tcl_version < (8, 5):
-        _stringify = True
 
     def create(self, **kwargs):
         return tkinter.Text(self.root, **kwargs)
@@ -560,12 +583,10 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkBooleanParam(widget, 'autoseparators')
 
-    @requires_tcl(8, 5)
     def test_configure_blockcursor(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'blockcursor')
 
-    @requires_tcl(8, 5)
     def test_configure_endline(self):
         widget = self.create()
         text = '\n'.join('Line %d' for i in range(100))
@@ -589,12 +610,11 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkIntegerParam(widget, 'maxundo', 0, 5, -1)
 
-    @requires_tcl(8, 5)
     def test_configure_inactiveselectbackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'inactiveselectbackground')
 
-    @requires_tcl(8, 6)
+    @requires_tk(8, 6)
     def test_configure_insertunfocussed(self):
         widget = self.create()
         self.checkEnumParam(widget, 'insertunfocussed',
@@ -603,8 +623,7 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
     def test_configure_selectborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'selectborderwidth',
-                              1.3, 2.6, -2, '10p', conv=noconv,
-                              keep_orig=tcl_version >= (8, 5))
+                              1.3, 2.6, -2, '10p', conv=False)
 
     def test_configure_spacing1(self):
         widget = self.create()
@@ -621,7 +640,6 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         self.checkPixelsParam(widget, 'spacing3', 20, 21.4, 22.6, '0.5c')
         self.checkParam(widget, 'spacing3', -10, expected=0)
 
-    @requires_tcl(8, 5)
     def test_configure_startline(self):
         widget = self.create()
         text = '\n'.join('Line %d' for i in range(100))
@@ -637,27 +655,18 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_state(self):
         widget = self.create()
-        if tcl_version < (8, 5):
-            self.checkParams(widget, 'state', 'disabled', 'normal')
-        else:
-            self.checkEnumParam(widget, 'state', 'disabled', 'normal')
+        self.checkEnumParam(widget, 'state', 'disabled', 'normal')
 
     def test_configure_tabs(self):
         widget = self.create()
-        if get_tk_patchlevel() < (8, 5, 11):
-            self.checkParam(widget, 'tabs', (10.2, 20.7, '1i', '2i'),
-                            expected=('10.2', '20.7', '1i', '2i'))
-        else:
-            self.checkParam(widget, 'tabs', (10.2, 20.7, '1i', '2i'))
+        self.checkParam(widget, 'tabs', (10.2, 20.7, '1i', '2i'))
         self.checkParam(widget, 'tabs', '10.2 20.7 1i 2i',
                         expected=('10.2', '20.7', '1i', '2i'))
         self.checkParam(widget, 'tabs', '2c left 4c 6c center',
                         expected=('2c', 'left', '4c', '6c', 'center'))
         self.checkInvalidParam(widget, 'tabs', 'spam',
-                               errmsg='bad screen distance "spam"',
-                               keep_orig=tcl_version >= (8, 5))
+                               errmsg='bad screen distance "spam"')
 
-    @requires_tcl(8, 5)
     def test_configure_tabstyle(self):
         widget = self.create()
         self.checkEnumParam(widget, 'tabstyle', 'tabular', 'wordprocessor')
@@ -674,10 +683,7 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_wrap(self):
         widget = self.create()
-        if tcl_version < (8, 5):
-            self.checkParams(widget, 'wrap', 'char', 'none', 'word')
-        else:
-            self.checkEnumParam(widget, 'wrap', 'char', 'none', 'word')
+        self.checkEnumParam(widget, 'wrap', 'char', 'none', 'word')
 
     def test_bbox(self):
         widget = self.create()
@@ -755,7 +761,165 @@ class CanvasTest(AbstractWidgetTest, unittest.TestCase):
         self.checkPixelsParam(widget, 'yscrollincrement',
                               10, 0, 11.2, 13.6, -10, '0.1i')
 
-    @requires_tcl(8, 6)
+    def _test_option_joinstyle(self, c, factory):
+        for joinstyle in 'bevel', 'miter', 'round':
+            i = factory(joinstyle=joinstyle)
+            self.assertEqual(c.itemcget(i, 'joinstyle'), joinstyle)
+        self.assertRaises(TclError, factory, joinstyle='spam')
+
+    def _test_option_smooth(self, c, factory):
+        for smooth in 1, True, '1', 'true', 'yes', 'on':
+            i = factory(smooth=smooth)
+            self.assertEqual(c.itemcget(i, 'smooth'), 'true')
+        for smooth in 0, False, '0', 'false', 'no', 'off':
+            i = factory(smooth=smooth)
+            self.assertEqual(c.itemcget(i, 'smooth'), '0')
+        i = factory(smooth=True, splinestep=30)
+        self.assertEqual(c.itemcget(i, 'smooth'), 'true')
+        self.assertEqual(c.itemcget(i, 'splinestep'), '30')
+        i = factory(smooth='raw', splinestep=30)
+        self.assertEqual(c.itemcget(i, 'smooth'), 'raw')
+        self.assertEqual(c.itemcget(i, 'splinestep'), '30')
+        self.assertRaises(TclError, factory, smooth='spam')
+
+    def test_create_rectangle(self):
+        c = self.create()
+        i1 = c.create_rectangle(20, 30, 60, 10)
+        self.assertEqual(c.coords(i1), [20.0, 10.0, 60.0, 30.0])
+        self.assertEqual(c.bbox(i1), (19, 9, 61, 31))
+
+        i2 = c.create_rectangle([21, 31, 61, 11])
+        self.assertEqual(c.coords(i2), [21.0, 11.0, 61.0, 31.0])
+        self.assertEqual(c.bbox(i2), (20, 10, 62, 32))
+
+        i3 = c.create_rectangle((22, 32), (62, 12))
+        self.assertEqual(c.coords(i3), [22.0, 12.0, 62.0, 32.0])
+        self.assertEqual(c.bbox(i3), (21, 11, 63, 33))
+
+        i4 = c.create_rectangle([(23, 33), (63, 13)])
+        self.assertEqual(c.coords(i4), [23.0, 13.0, 63.0, 33.0])
+        self.assertEqual(c.bbox(i4), (22, 12, 64, 34))
+
+        self.assertRaises(TclError, c.create_rectangle, 20, 30, 60)
+        self.assertRaises(TclError, c.create_rectangle, [20, 30, 60])
+        self.assertRaises(TclError, c.create_rectangle, 20, 30, 40, 50, 60, 10)
+        self.assertRaises(TclError, c.create_rectangle, [20, 30, 40, 50, 60, 10])
+        self.assertRaises(TclError, c.create_rectangle, 20, 30)
+        self.assertRaises(TclError, c.create_rectangle, [20, 30])
+        self.assertRaises(IndexError, c.create_rectangle)
+        self.assertRaises(IndexError, c.create_rectangle, [])
+
+    def test_create_line(self):
+        c = self.create()
+        i1 = c.create_line(20, 30, 40, 50, 60, 10)
+        self.assertEqual(c.coords(i1), [20.0, 30.0, 40.0, 50.0, 60.0, 10.0])
+        self.assertEqual(c.bbox(i1), (18, 8, 62, 52))
+        self.assertEqual(c.itemcget(i1, 'arrow'), 'none')
+        self.assertEqual(c.itemcget(i1, 'arrowshape'), '8 10 3')
+        self.assertEqual(c.itemcget(i1, 'capstyle'), 'butt')
+        self.assertEqual(c.itemcget(i1, 'joinstyle'), 'round')
+        self.assertEqual(c.itemcget(i1, 'smooth'), '0')
+        self.assertEqual(c.itemcget(i1, 'splinestep'), '12')
+
+        i2 = c.create_line([21, 31, 41, 51, 61, 11])
+        self.assertEqual(c.coords(i2), [21.0, 31.0, 41.0, 51.0, 61.0, 11.0])
+        self.assertEqual(c.bbox(i2), (19, 9, 63, 53))
+
+        i3 = c.create_line((22, 32), (42, 52), (62, 12))
+        self.assertEqual(c.coords(i3), [22.0, 32.0, 42.0, 52.0, 62.0, 12.0])
+        self.assertEqual(c.bbox(i3), (20, 10, 64, 54))
+
+        i4 = c.create_line([(23, 33), (43, 53), (63, 13)])
+        self.assertEqual(c.coords(i4), [23.0, 33.0, 43.0, 53.0, 63.0, 13.0])
+        self.assertEqual(c.bbox(i4), (21, 11, 65, 55))
+
+        self.assertRaises(TclError, c.create_line, 20, 30, 60)
+        self.assertRaises(TclError, c.create_line, [20, 30, 60])
+        self.assertRaises(TclError, c.create_line, 20, 30)
+        self.assertRaises(TclError, c.create_line, [20, 30])
+        self.assertRaises(IndexError, c.create_line)
+        self.assertRaises(IndexError, c.create_line, [])
+
+        for arrow in 'none', 'first', 'last', 'both':
+            i = c.create_line(20, 30, 60, 10, arrow=arrow)
+            self.assertEqual(c.itemcget(i, 'arrow'), arrow)
+        i = c.create_line(20, 30, 60, 10, arrow='first', arrowshape=[10, 15, 5])
+        self.assertEqual(c.itemcget(i, 'arrowshape'), '10 15 5')
+        self.assertRaises(TclError, c.create_line, 20, 30, 60, 10, arrow='spam')
+
+        for capstyle in 'butt', 'projecting', 'round':
+            i = c.create_line(20, 30, 60, 10, capstyle=capstyle)
+            self.assertEqual(c.itemcget(i, 'capstyle'), capstyle)
+        self.assertRaises(TclError, c.create_line, 20, 30, 60, 10, capstyle='spam')
+
+        self._test_option_joinstyle(c,
+                lambda **kwargs: c.create_line(20, 30, 40, 50, 60, 10, **kwargs))
+        self._test_option_smooth(c,
+                lambda **kwargs: c.create_line(20, 30, 60, 10, **kwargs))
+
+    def test_create_polygon(self):
+        c = self.create()
+        i1 = c.create_polygon(20, 30, 40, 50, 60, 10)
+        self.assertEqual(c.coords(i1), [20.0, 30.0, 40.0, 50.0, 60.0, 10.0])
+        self.assertEqual(c.bbox(i1), (19, 9, 61, 51))
+        self.assertEqual(c.itemcget(i1, 'joinstyle'), 'round')
+        self.assertEqual(c.itemcget(i1, 'smooth'), '0')
+        self.assertEqual(c.itemcget(i1, 'splinestep'), '12')
+
+        i2 = c.create_polygon([21, 31, 41, 51, 61, 11])
+        self.assertEqual(c.coords(i2), [21.0, 31.0, 41.0, 51.0, 61.0, 11.0])
+        self.assertEqual(c.bbox(i2), (20, 10, 62, 52))
+
+        i3 = c.create_polygon((22, 32), (42, 52), (62, 12))
+        self.assertEqual(c.coords(i3), [22.0, 32.0, 42.0, 52.0, 62.0, 12.0])
+        self.assertEqual(c.bbox(i3), (21, 11, 63, 53))
+
+        i4 = c.create_polygon([(23, 33), (43, 53), (63, 13)])
+        self.assertEqual(c.coords(i4), [23.0, 33.0, 43.0, 53.0, 63.0, 13.0])
+        self.assertEqual(c.bbox(i4), (22, 12, 64, 54))
+
+        self.assertRaises(TclError, c.create_polygon, 20, 30, 60)
+        self.assertRaises(TclError, c.create_polygon, [20, 30, 60])
+        self.assertRaises(IndexError, c.create_polygon)
+        self.assertRaises(IndexError, c.create_polygon, [])
+
+        self._test_option_joinstyle(c,
+                lambda **kwargs: c.create_polygon(20, 30, 40, 50, 60, 10, **kwargs))
+        self._test_option_smooth(c,
+                lambda **kwargs: c.create_polygon(20, 30, 40, 50, 60, 10, **kwargs))
+
+    def test_coords(self):
+        c = self.create()
+        i = c.create_line(20, 30, 40, 50, 60, 10, tags='x')
+        self.assertEqual(c.coords(i), [20.0, 30.0, 40.0, 50.0, 60.0, 10.0])
+        self.assertEqual(c.coords('x'), [20.0, 30.0, 40.0, 50.0, 60.0, 10.0])
+        self.assertEqual(c.bbox(i), (18, 8, 62, 52))
+
+        c.coords(i, 50, 60, 70, 80, 90, 40)
+        self.assertEqual(c.coords(i), [50.0, 60.0, 70.0, 80.0, 90.0, 40.0])
+        self.assertEqual(c.bbox(i), (48, 38, 92, 82))
+
+        c.coords(i, [21, 31, 41, 51, 61, 11])
+        self.assertEqual(c.coords(i), [21.0, 31.0, 41.0, 51.0, 61.0, 11.0])
+
+        c.coords(i, 20, 30, 60, 10)
+        self.assertEqual(c.coords(i), [20.0, 30.0, 60.0, 10.0])
+        self.assertEqual(c.bbox(i), (18, 8, 62, 32))
+
+        self.assertRaises(TclError, c.coords, i, 20, 30, 60)
+        self.assertRaises(TclError, c.coords, i, [20, 30, 60])
+        self.assertRaises(TclError, c.coords, i, 20, 30)
+        self.assertRaises(TclError, c.coords, i, [20, 30])
+
+        c.coords(i, '20', '30c', '60i', '10p')
+        coords = c.coords(i)
+        self.assertIsInstance(coords, list)
+        self.assertEqual(len(coords), 4)
+        self.assertEqual(coords[0], 20)
+        for i in range(4):
+            self.assertIsInstance(coords[i], float)
+
+    @requires_tk(8, 6)
     def test_moveto(self):
         widget = self.create()
         i1 = widget.create_rectangle(1, 1, 20, 20, tags='group')
@@ -800,7 +964,7 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         self.checkEnumParam(widget, 'activestyle',
                             'dotbox', 'none', 'underline')
 
-    test_justify = requires_tcl(8, 6, 5)(StandardOptionsTests.test_configure_justify)
+    test_configure_justify = requires_tk(8, 6, 5)(StandardOptionsTests.test_configure_justify)
 
     def test_configure_listvariable(self):
         widget = self.create()
@@ -939,7 +1103,7 @@ class ScaleTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_from(self):
         widget = self.create()
-        conv = False if get_tk_patchlevel() >= (8, 6, 10) else float_round
+        conv = float if get_tk_patchlevel(self.root) >= (8, 6, 10) else float_round
         self.checkFloatParam(widget, 'from', 100, 14.9, 15.1, conv=conv)
 
     def test_configure_label(self):
@@ -1055,30 +1219,30 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def test_configure_handlesize(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'handlesize', 8, 9.4, 10.6, -3, '2m',
-                              conv=noconv)
+                              conv=False)
 
     def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, 101.2, 102.6, -100, 0, '1i',
-                              conv=noconv)
+                              conv=False)
 
     def test_configure_opaqueresize(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'opaqueresize')
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxybackground(self):
         widget = self.create()
         self.checkColorParam(widget, 'proxybackground')
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxyborderwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'proxyborderwidth',
                               0, 1.3, 2.9, 6, -2, '10p',
-                              conv=noconv)
+                              conv=False)
 
-    @requires_tcl(8, 6, 5)
+    @requires_tk(8, 6, 5)
     def test_configure_proxyrelief(self):
         widget = self.create()
         self.checkReliefParam(widget, 'proxyrelief')
@@ -1098,7 +1262,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def test_configure_sashwidth(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'sashwidth', 10, 11.1, 15.6, -3, '1m',
-                              conv=noconv)
+                              conv=False)
 
     def test_configure_showhandle(self):
         widget = self.create()
@@ -1107,7 +1271,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def test_configure_width(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'width', 402, 403.4, 404.6, -402, 0, '5i',
-                              conv=noconv)
+                              conv=False)
 
     def create2(self):
         p = self.create()
@@ -1127,15 +1291,12 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
             self.assertEqual(v, p.paneconfigure(b, k))
             self.assertEqual(v[4], p.panecget(b, k))
 
-    def check_paneconfigure(self, p, b, name, value, expected, stringify=False):
-        conv = lambda x: x
-        if not self.wantobjects or stringify:
+    def check_paneconfigure(self, p, b, name, value, expected):
+        if not self.wantobjects:
             expected = str(expected)
-        if self.wantobjects and stringify:
-            conv = str
         p.paneconfigure(b, **{name: value})
-        self.assertEqual(conv(p.paneconfigure(b, name)[4]), expected)
-        self.assertEqual(conv(p.panecget(b, name)), expected)
+        self.assertEqual(p.paneconfigure(b, name)[4], expected)
+        self.assertEqual(p.panecget(b, name), expected)
 
     def check_paneconfigure_bad(self, p, b, name, msg):
         with self.assertRaisesRegex(TclError, msg):
@@ -1155,12 +1316,10 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_paneconfigure_height(self):
         p, b, c = self.create2()
-        self.check_paneconfigure(p, b, 'height', 10, 10,
-                                 stringify=get_tk_patchlevel() < (8, 5, 11))
+        self.check_paneconfigure(p, b, 'height', 10, 10)
         self.check_paneconfigure_bad(p, b, 'height',
                                      'bad screen distance "badValue"')
 
-    @requires_tcl(8, 5)
     def test_paneconfigure_hide(self):
         p, b, c = self.create2()
         self.check_paneconfigure(p, b, 'hide', False, 0)
@@ -1193,7 +1352,6 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
                                      'be a string containing zero or more of '
                                      'n, e, s, and w')
 
-    @requires_tcl(8, 5)
     def test_paneconfigure_stretch(self):
         p, b, c = self.create2()
         self.check_paneconfigure(p, b, 'stretch', 'alw', 'always')
@@ -1203,8 +1361,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_paneconfigure_width(self):
         p, b, c = self.create2()
-        self.check_paneconfigure(p, b, 'width', 10, 10,
-                                 stringify=get_tk_patchlevel() < (8, 5, 11))
+        self.check_paneconfigure(p, b, 'width', 10, 10)
         self.check_paneconfigure_bad(p, b, 'width',
                                      'bad screen distance "badValue"')
 
@@ -1218,10 +1375,15 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
         'postcommand', 'relief', 'selectcolor', 'takefocus',
         'tearoff', 'tearoffcommand', 'title', 'type',
     )
-    _conv_pixels = noconv
+    _conv_pixels = False
 
     def create(self, **kwargs):
         return tkinter.Menu(self.root, **kwargs)
+
+    def test_indexcommand_none(self):
+        widget = self.create()
+        i = widget.index('none')
+        self.assertIsNone(i)
 
     def test_configure_postcommand(self):
         widget = self.create()
@@ -1241,10 +1403,13 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_type(self):
         widget = self.create()
+        opts = ('normal, tearoff, or menubar'
+                if widget.info_patchlevel() < (8, 7) else
+                'menubar, normal, or tearoff')
         self.checkEnumParam(
             widget, 'type',
             'normal', 'tearoff', 'menubar',
-            errmsg='bad type "{}": must be normal, tearoff, or menubar',
+            errmsg='bad type "{}": must be ' + opts,
             )
 
     def test_entryconfigure(self):
@@ -1290,7 +1455,7 @@ class MessageTest(AbstractWidgetTest, unittest.TestCase):
         'justify', 'padx', 'pady', 'relief',
         'takefocus', 'text', 'textvariable', 'width',
     )
-    _conv_pad_pixels = noconv
+    _conv_pad_pixels = False
 
     def create(self, **kwargs):
         return tkinter.Message(self.root, **kwargs)

--- a/tkinter/test/test_ttk/test_style.py
+++ b/tkinter/test/test_ttk/test_style.py
@@ -4,7 +4,7 @@ import tkinter
 from tkinter import ttk
 from test import support
 from test.support import requires
-from tkinter.test.support import AbstractTkTest
+from tkinter.test.support import AbstractTkTest, get_tk_patchlevel
 
 requires('gui')
 
@@ -170,6 +170,8 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
                     newname = f'C.{name}'
                     self.assertEqual(style.map(newname), {})
                     style.map(newname, **default)
+                    if theme == 'alt' and name == '.' and get_tk_patchlevel(self.root) < (8, 6, 1):
+                        default['embossed'] = [('disabled', '1')]
                     self.assertEqual(style.map(newname), default)
                     for key, value in default.items():
                         self.assertEqual(style.map(newname, key), value)

--- a/tkinter/test/test_ttk/test_widgets.py
+++ b/tkinter/test/test_ttk/test_widgets.py
@@ -5,9 +5,9 @@ from test.support import requires, gc_collect
 import sys
 
 from test.test_ttk_textonly import MockTclObj
-from tkinter.test.support import (AbstractTkTest, tcl_version, get_tk_patchlevel,
+from tkinter.test.support import (AbstractTkTest, tk_version, get_tk_patchlevel,
                                   simulate_mouse_click, AbstractDefaultRootTest)
-from tkinter.test.widget_tests import (add_standard_options, noconv,
+from tkinter.test.widget_tests import (add_standard_options,
     AbstractWidgetTest, StandardOptionsTests, IntegerSizeTests, PixelSizeTests,
     setUpModule)
 
@@ -20,7 +20,7 @@ class StandardTtkOptionsTests(StandardOptionsTests):
         widget = self.create()
         self.assertEqual(widget['class'], '')
         errmsg='attempt to change read-only option'
-        if get_tk_patchlevel() < (8, 6, 0, 'beta', 3):
+        if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
             errmsg='Attempt to change read-only option'
         self.checkInvalidParam(widget, 'class', 'Foo', errmsg=errmsg)
         widget2 = self.create(class_='Foo')
@@ -110,7 +110,7 @@ class WidgetTest(AbstractTkTest, unittest.TestCase):
 
 
 class AbstractToplevelTest(AbstractWidgetTest, PixelSizeTests):
-    _conv_pixels = noconv
+    _conv_pixels = False
 
 
 @add_standard_options(StandardTtkOptionsTests)
@@ -193,7 +193,7 @@ class LabelTest(AbstractLabelTest, unittest.TestCase):
         'takefocus', 'text', 'textvariable',
         'underline', 'width', 'wraplength',
     )
-    _conv_pixels = noconv
+    _conv_pixels = False
 
     def create(self, **kwargs):
         return ttk.Label(self.root, **kwargs)
@@ -274,6 +274,21 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
         self.assertLessEqual(len(success), 1)
         self.assertEqual(cbtn['offvalue'],
             cbtn.tk.globalgetvar(cbtn['variable']))
+
+    def test_unique_variables(self):
+        frames = []
+        buttons = []
+        for i in range(2):
+            f = ttk.Frame(self.root)
+            f.pack()
+            frames.append(f)
+            for j in 'AB':
+                b = ttk.Checkbutton(f, text=j)
+                b.pack()
+                buttons.append(b)
+        variables = [str(b['variable']) for b in buttons]
+        print(variables)
+        self.assertEqual(len(set(variables)), 4, variables)
 
 
 @add_standard_options(IntegerSizeTests, StandardTtkOptionsTests)
@@ -473,8 +488,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
             self.assertEqual(self.combo.get(), getval)
             self.assertEqual(self.combo.current(), currval)
 
-        self.assertEqual(self.combo['values'],
-                         () if tcl_version < (8, 5) else '')
+        self.assertEqual(self.combo['values'], '')
         check_get_current('', -1)
 
         self.checkParam(self.combo, 'values', 'mon tue wed thur',
@@ -548,7 +562,7 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.assertEqual(str(widget['orient']), 'vertical')
         errmsg='attempt to change read-only option'
-        if get_tk_patchlevel() < (8, 6, 0, 'beta', 3):
+        if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
             errmsg='Attempt to change read-only option'
         self.checkInvalidParam(widget, 'orient', 'horizontal',
                 errmsg=errmsg)
@@ -741,7 +755,7 @@ class ScaleTest(AbstractWidgetTest, unittest.TestCase):
         'class', 'command', 'cursor', 'from', 'length',
         'orient', 'style', 'takefocus', 'to', 'value', 'variable',
     )
-    _conv_pixels = noconv
+    _conv_pixels = False
     default_orient = 'horizontal'
 
     def setUp(self):
@@ -848,7 +862,7 @@ class ProgressbarTest(AbstractWidgetTest, unittest.TestCase):
         'mode', 'maximum', 'phase',
         'style', 'takefocus', 'value', 'variable',
     )
-    _conv_pixels = noconv
+    _conv_pixels = False
     default_orient = 'horizontal'
 
     def create(self, **kwargs):
@@ -1231,8 +1245,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertEqual(self.spin.get(), '1')
 
     def test_configure_values(self):
-        self.assertEqual(self.spin['values'],
-                         () if tcl_version < (8, 5) else '')
+        self.assertEqual(self.spin['values'], '')
         self.checkParam(self.spin, 'values', 'mon tue wed thur',
                         expected=('mon', 'tue', 'wed', 'thur'))
         self.checkParam(self.spin, 'values', ('mon', 'tue', 'wed', 'thur'))
@@ -1316,7 +1329,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
     def test_configure_height(self):
         widget = self.create()
         self.checkPixelsParam(widget, 'height', 100, -100, 0, '3c', conv=False)
-        self.checkPixelsParam(widget, 'height', 101.2, 102.6, conv=noconv)
+        self.checkPixelsParam(widget, 'height', 101.2, 102.6, conv=False)
 
     def test_configure_selectmode(self):
         widget = self.create()
@@ -1515,7 +1528,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_heading_callback(self):
         def simulate_heading_click(x, y):
-            if tcl_version >= (8, 6):
+            if tk_version >= (8, 6):
                 self.assertEqual(self.tv.identify_column(x), '#0')
                 self.assertEqual(self.tv.identify_region(x, y), 'heading')
             simulate_mouse_click(self.tv, x, y)

--- a/tkinter/tix.py
+++ b/tkinter/tix.py
@@ -21,13 +21,20 @@
 # Compare the demo tixwidgets.py to the original Tcl program and you will
 # appreciate the advantages.
 #
+# NOTE: This module is deprecated since Python 3.6.
 
 import os
+import warnings
 import tkinter
 from tkinter import *
 from tkinter import _cnfmerge
 
-import _tkinter # If this fails your Python may not be configured for Tk
+warnings.warn(
+    'The Tix Tk extension is unmaintained, and the tkinter.tix wrapper module'
+    ' is deprecated in favor of tkinter.ttk',
+    DeprecationWarning,
+    stacklevel=2,
+    )
 
 # Some more constants (for consistency with Tkinter)
 WINDOW = 'window'
@@ -303,7 +310,7 @@ class TixWidget(tkinter.Widget):
                 del cnf[k]
 
         self.widgetName = widgetName
-        Widget._setup(self, master, cnf)
+        self._setup(master, cnf)
 
         # If widgetName is None, this is a dummy creation call where the
         # corresponding Tk widget has already been created by Tix
@@ -386,7 +393,7 @@ class TixWidget(tkinter.Widget):
             self.tk.call(name, 'configure', '-' + option, value)
     # These are missing from Tkinter
     def image_create(self, imgtype, cnf={}, master=None, **kw):
-        if not master:
+        if master is None:
             master = self
         if kw and cnf: cnf = _cnfmerge((cnf, kw))
         elif kw: cnf = kw
@@ -467,7 +474,7 @@ class DisplayStyle:
     (multiple) Display Items"""
 
     def __init__(self, itemtype, cnf={}, *, master=None, **kw):
-        if not master:
+        if master is None:
             if 'refwindow' in kw:
                 master = kw['refwindow']
             elif 'refwindow' in cnf:
@@ -862,7 +869,7 @@ class HList(TixWidget, XView, YView):
         return self.tk.call(self._w, 'add', entry, *self._options(cnf, kw))
 
     def add_child(self, parent=None, cnf={}, **kw):
-        if not parent:
+        if parent is None:
             parent = ''
         return self.tk.call(
                      self._w, 'addchild', parent, *self._options(cnf, kw))

--- a/tkinter/ttk.py
+++ b/tkinter/ttk.py
@@ -28,23 +28,6 @@ __all__ = ["Button", "Checkbutton", "Combobox", "Entry", "Frame", "Label",
 import tkinter
 from tkinter import _flatten, _join, _stringify, _splitdict
 
-# Verify if Tk is new enough to not need the Tile package
-_REQUIRE_TILE = True if tkinter.TkVersion < 8.5 else False
-
-def _load_tile(master):
-    if _REQUIRE_TILE:
-        import os
-        tilelib = os.environ.get('TILE_LIBRARY')
-        if tilelib:
-            # append custom tile path to the list of directories that
-            # Tcl uses when attempting to resolve packages with the package
-            # command
-            master.tk.eval(
-                    'global auto_path; '
-                    'lappend auto_path {%s}' % tilelib)
-
-        master.tk.eval('package require tile') # TclError may be raised here
-        master._tile_loaded = True
 
 def _format_optvalue(value, script=False):
     """Internal function."""
@@ -360,11 +343,6 @@ class Style(object):
 
     def __init__(self, master=None):
         master = setup_master(master)
-
-        if not getattr(master, '_tile_loaded', False):
-            # Load tile now, if needed
-            _load_tile(master)
-
         self.master = master
         self.tk = self.master.tk
 
@@ -546,9 +524,6 @@ class Widget(tkinter.Widget):
             readonly, alternate, invalid
         """
         master = setup_master(master)
-        if not getattr(master, '_tile_loaded', False):
-            # Load tile now, if needed
-            _load_tile(master)
         tkinter.Widget.__init__(self, master, widgetname, kw=kw)
 
 
@@ -569,7 +544,7 @@ class Widget(tkinter.Widget):
         matches statespec. statespec is expected to be a sequence."""
         ret = self.tk.getboolean(
                 self.tk.call(self._w, "instate", ' '.join(statespec)))
-        if ret and callback:
+        if ret and callback is not None:
             return callback(*args, **kw)
 
         return ret


### PR DESCRIPTION
This is just an update for tkinter from cython branch 3.11.
I decide to update when the tkinter software failed to run with the error,
```
>>> import tkinter 
Traceback (most recent call last): 
 File "<stdin>", line 1, in <module> 
 File "/app/lib/python3.11/site-packages/tkinter/__init__.py", line 36, in <module> 
   import _tkinter # If this fails your Python may not be configured for Tk 
   ^^^^^^^^^^^^^^^ 
ImportError: /app/lib/python3.11/site-packages/_tkinter.cpython-311-x86_64-linux-gnu.so: undefined symbol: _PyObject_CallNoArg
```